### PR TITLE
Improve ordering of steps for setting up API Gateway invocation role

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ arn:aws:apigateway:<YOUR REGION>:lambda:path/2015-03-31/functions/<YOUR LAMBDA F
 	]
 }
 ```
+* Copy the **Role ARN** from the Role Summary page, and paste it in the `credentials` field of the `/users` and `/login` methods of the Swagger file.
 * Now that we have generated all resources for our API and we have all the ARNs, we should also modify the access policy of the Cognito Identity Pool to match the generated one.
 * In the IAM console navigate to the roles list and open the authenticated role of your Cognito Identity Pool - the role is likely to be called **Cognito_"IdentityPoolName"Auth_Role**
 * Copy and paste the same access policy we generated for the invocation role with the addition of the permission to invoke API Gateway: Add an **Action** called `execute-api:Invoke` and a **Resource** called `arn:aws:execute-api:*`
-* Copy the **Role ARN** from the Role Summary page, and paste it in the `credentials` field of the `/users` and `/login` methods of the Swagger file.
 * Once you have modified and saved the Swagger file to call the correct Lambda function and use your roles run the Swagger Importer tool from the command line to create the API in Amazon API Gateway. The Swagger Importer uses your local [AWS credentials set by the AWS cli](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files). From the Swagger Importer tool folder run:
 ```
 ./aws-api-import.sh --create /path/to/secure-pet-store/src/main/resources/swagger.yaml


### PR DESCRIPTION
The instruction to update the swagger file after updating Cognito's authenticated role makes it confusing (at least to a newbie like me) as to which role to use in the `credentials` field, i.e. the newly created role or Cognito's.
